### PR TITLE
Add `Join PrestoDB on Slack` link on doc pages

### DIFF
--- a/presto-docs/src/main/sphinx/_templates/partials/toc.html
+++ b/presto-docs/src/main/sphinx/_templates/partials/toc.html
@@ -40,6 +40,14 @@ This file was automatically generated - do not edit
                 Create project issue
             </a>
         </li>
+        <li class="md-nav__item">
+            <a href="https://communityinviter.com/apps/prestodb/prestodb" class="">
+                <span class="md-source__icon  md-icon">
+                    {% include ".icons/fontawesome/brands/slack.svg" %}
+                </span>
+                Join PrestoDB on Slack
+            </a>
+        </li>
     </ul>
     <hr>
     {% set toc = page.toc %}

--- a/presto-ui/src/components/QueryViewer.jsx
+++ b/presto-ui/src/components/QueryViewer.jsx
@@ -78,6 +78,7 @@ export function QueryViewer() {
     };
 
 
+
     return (
         <div>
             <FileForm onChange={readJSON} />


### PR DESCRIPTION
Adding a link in the document pages to encourage users to join the PrestoDB Slack when seeking help.

## Description
<!---Describe your changes in detail-->

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [contributing guide](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md), in particular [code style](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#code-style) and [commit standards](https://github.com/prestodb/presto/blob/master/CONTRIBUTING.md#commit-standards).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ... 
* ... 

Hive Connector Changes
* ... 
* ... 
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

